### PR TITLE
Flip gba bitorder color format

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -2,7 +2,7 @@ use interconnect::InterconnectWrite;
 use glium::{self, DisplayBuild, Frame, Surface};
 use glium::texture::RawImage2d;
 use glium::texture::ClientFormat;
-use utils::u1u5u5u5_to_u5u5u5u1;
+use utils::gba_to_display_format;
 
 pub struct Display {
     pub display: glium::backend::glutin_backend::GlutinFacade,
@@ -105,7 +105,7 @@ impl Display {
 
 impl InterconnectWrite for Display {
     fn write(&mut self, address: u32, word: u32) {
-        self.buf[address as usize] = u1u5u5u5_to_u5u5u5u1(word as u16);
+        self.buf[address as usize] = gba_to_display_format(word as u16);
         self.vsync();
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -2,7 +2,7 @@ use interconnect::InterconnectWrite;
 use glium::{self, DisplayBuild, Frame, Surface};
 use glium::texture::RawImage2d;
 use glium::texture::ClientFormat;
-use utils::RGB;
+use utils::u1u5u5u5_to_u5u5u5u1;
 
 pub struct Display {
     pub display: glium::backend::glutin_backend::GlutinFacade,
@@ -105,14 +105,7 @@ impl Display {
 
 impl InterconnectWrite for Display {
     fn write(&mut self, address: u32, word: u32) {
-        let u1u5u5u5 = word as u16;
-        let u5u5u5u1 = (
-                (u1u5u5u5 & 0b0_00000_00000_11111) << 11 | // Red
-                (u1u5u5u5 & 0b0_00000_11111_00000) << 1  | // Green
-                (u1u5u5u5 & 0b0_11111_00000_00000) >> 10   // Blue
-        );
-        self.buf[address as usize] = u5u5u5u1;
-
+        self.buf[address as usize] = u1u5u5u5_to_u5u5u5u1(word as u16);
         self.vsync();
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -105,7 +105,13 @@ impl Display {
 
 impl InterconnectWrite for Display {
     fn write(&mut self, address: u32, word: u32) {
-        self.buf[address as usize] = word as u16;
+        let u1u5u5u5 = word as u16;
+        let u5u5u5u1 = (
+                (u1u5u5u5 & 0b0_00000_00000_11111) << 11 | // Red
+                (u1u5u5u5 & 0b0_00000_11111_00000) << 1  | // Green
+                (u1u5u5u5 & 0b0_11111_00000_00000) >> 10   // Blue
+        );
+        self.buf[address as usize] = u5u5u5u1;
 
         self.vsync();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,9 +44,9 @@ fn run() -> Result<()> {
     gba.interconnect.write(ioram_base, 0x03);
 
     let vram_base = 0x06000000;
-    gba.interconnect.write(vram_base + 80 * 240 + 115, 0b11111_00000_00000_0);
-    gba.interconnect.write(vram_base + 80 * 240 + 120, 0b00000_11111_00000_0);
-    gba.interconnect.write(vram_base + 80 * 240 + 125, 0b00000_00000_11111_0);
+    gba.interconnect.write(vram_base + 80 * 240 + 115, 0b0_00000_00000_11111);
+    gba.interconnect.write(vram_base + 80 * 240 + 120, 0b0_00000_11111_00000);
+    gba.interconnect.write(vram_base + 80 * 240 + 125, 0b0_11111_00000_00000);
 
     loop {
         for ev in gba.interconnect.display.display.poll_events() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn run() -> Result<()> {
     // Use video mode 3 (in BG2, a 16bpp bitmap in VRAM)
     gba.interconnect.write(ioram_base, 0x03);
     // Enable BG2 (BG0 = 1, BG1 = 2, BG2 = 4, ...)
-    gba.interconnect.write(ioram_base, 0x03);
+    gba.interconnect.write(ioram_base + 1, 0x03);
 
     let vram_base = 0x06000000;
     gba.interconnect.write(vram_base + 80 * 240 + 115, 0b0_00000_00000_11111);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,18 +1,18 @@
-pub fn u1u5u5u5_to_u5u5u5u1(u1u5u5u5: u16) -> u16 {
-    (u1u5u5u5 & 0b0_00000_00000_11111) << 11 | // Red
-        (u1u5u5u5 & 0b0_00000_11111_00000) << 1  | // Green
-        (u1u5u5u5 & 0b0_11111_00000_00000) >> 9 // Blue
+pub fn gba_to_display_format(gba_format: u16) -> u16 {
+    (gba_format & 0b0_00000_00000_11111) << 11 | // Red
+        (gba_format & 0b0_00000_11111_00000) << 1  | // Green
+        (gba_format & 0b0_11111_00000_00000) >> 9 // Blue
 }
 
 #[cfg(test)]
 mod tests {
-    use super::u1u5u5u5_to_u5u5u5u1;
+    use super::gba_to_display_format;
 
     #[test]
     fn test_display_format_conversion() {
         let gba_format = 0b0_10001_11111_00000;
         let display_format = 0b00000_11111_10001_0;
 
-        assert_eq!(u1u5u5u5_to_u5u5u5u1(gba_format), display_format);
+        assert_eq!(gba_to_display_format(gba_format), display_format);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,22 +1,18 @@
-#[derive(Debug)]
-pub struct RGB {
-    red: u8,
-    green: u8,
-    blue: u8,
+pub fn u1u5u5u5_to_u5u5u5u1(u1u5u5u5: u16) -> u16 {
+    (u1u5u5u5 & 0b0_00000_00000_11111) << 11 | // Red
+        (u1u5u5u5 & 0b0_00000_11111_00000) << 1  | // Green
+        (u1u5u5u5 & 0b0_11111_00000_00000) >> 9 // Blue
 }
 
-impl RGB {
-    pub fn as_u8(&self) -> (u8, u8, u8) {
-        (0, 0, 0)
-    }
-}
+#[cfg(test)]
+mod tests {
+    use super::u1u5u5u5_to_u5u5u5u1;
 
-impl From<u16> for RGB {
-    fn from(num: u16) -> Self {
-        RGB {
-            red: (num & 0b0000000000011111) as u8,
-            green: ((num & 0b0000001111100000) >> 5) as u8,
-            blue: ((num & 0b0111110000000000) >> 10) as u8,
-        }
+    #[test]
+    fn test_display_format_conversion() {
+        let gba_format = 0b0_10001_11111_00000;
+        let display_format = 0b00000_11111_10001_0;
+
+        assert_eq!(u1u5u5u5_to_u5u5u5u1(gba_format), display_format);
     }
 }


### PR DESCRIPTION
Glium expects rgba, while the gba expects abgr.
We now transparently flip the bits before writing to the actual display.